### PR TITLE
avoid storage key collision

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,4 +11,4 @@ module.exports = (function detectLocalStorage (localStorage, data) {
   } catch (_) {
     return false
   }
-})(window.localStorage, 'HAS_LOCAL_STORAGE')
+})(window.localStorage, 'HAS_LOCAL_STORAGE_' + (new Date().getTime()))


### PR DESCRIPTION
Make sure it doesn't conflict with other libraries.

For the record: I'm not sure about the browser support, but if you'd prefer `Date.now()` that's just fine but now it doesn't throw exception in older browsers.
