### PR TITLE
remove unnecessary setItem invocation

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var window = require('global/window')
 module.exports = (function detectLocalStorage (localStorage, data) {
   if (!localStorage) return false
   try {
-    localStorage.setItem(data, data)
     localStorage.removeItem(data)
     return true
   } catch (_) {


### PR DESCRIPTION
Since the specification points it out, it's just fine to call only `removeItem`.

http://www.w3.org/TR/webstorage/#storage-0
